### PR TITLE
[CatalyzeX] Introduce "Related Code" link for papers with no code available

### DIFF
--- a/browse/static/js/catalyzex.js
+++ b/browse/static/js/catalyzex.js
@@ -1,5 +1,9 @@
 (async () => {
-  const arxivId = document.head.querySelector("[name~=citation_arxiv_id][content]").content;
+  let arxivId = window.location.pathname.split('/').reverse()[0];
+  if(!arxivId) return;
+
+  arxivId = arxivId.replace(/v.*/, '') // remove version number
+
   const paperTitle = document.querySelector("h1.title")?.innerText;
   const paperUrl = window.location.href.split('?')[0];
   const $output = $("#catalyzex-output");

--- a/browse/static/js/catalyzex.js
+++ b/browse/static/js/catalyzex.js
@@ -32,6 +32,21 @@
     return result;
   };
 
+  const fetchRelatedPapersWithCode = async () => {
+    const cxRelatedCodeApi = new URL(`https://www.catalyzex.com/api/v1/paper/arxiv:${arxivId}/code/related`);
+    if(paperTitle) cxRelatedCodeApi.searchParams.set('paper_title', paperTitle);
+
+    let result = {};
+
+    try {
+      result = await $.ajax({ url: cxRelatedCodeApi, timeout: 2000, dataType: "json" });
+    } catch (error) {
+      result = {};
+    }
+
+    return result;
+  };
+
   $output.html('');
 
   const { count: implementations, cx_url: cxImplementationsUrl } = await fetchCatalyzeXCode()
@@ -58,10 +73,13 @@
   } else {
     $output.append(`<p>No code found for this paper just yet.</p>`)
 
-    const relatedCodeURL = new URL(`https://www.catalyzex.com/paper/arxiv:${arxivId}/code/related`);
-    if(paperTitle) relatedCodeURL.searchParams.set('paperTitle', paperTitle);
-    
-    $output.append(`<p>See <a target="_blank" href="${relatedCodeURL}" style="font-weight:bold">code for related papers</a>.</p>`)
+    const { related_papers: relatedPapersWithCode } = await fetchRelatedPapersWithCode(paperTitle);
+
+    if(relatedPapersWithCode?.length > 0) {
+      const relatedCodeURL = new URL(`https://www.catalyzex.com/paper/arxiv:${arxivId}/code/related`);
+      if(paperTitle) relatedCodeURL.searchParams.set('paperTitle', paperTitle);
+      $output.append(`<p>See <a target="_blank" href="${relatedCodeURL}" style="font-weight:bold">code for related papers</a>.</p>`)
+    }
   }
   $output.append(`<p>If you have code to share with the arXiv community, please ${submitItHereLink} to benefit all researchers & engineers.</p>`)
 })();

--- a/browse/static/js/catalyzex.js
+++ b/browse/static/js/catalyzex.js
@@ -57,7 +57,10 @@
       .append(codeLink)
   } else {
     $output.append(`<p>No code found for this paper just yet.</p>`)
-    const relatedCodeURL = `https://www.catalyzex.com/paper/arxiv:${arxivId}/code/related`
+
+    const relatedCodeURL = new URL(`https://www.catalyzex.com/paper/arxiv:${arxivId}/code/related`);
+    if(paperTitle) relatedCodeURL.searchParams.set('paperTitle', paperTitle);
+    
     $output.append(`<p>See <a target="_blank" href="${relatedCodeURL}" style="font-weight:bold">code for related papers</a>.</p>`)
   }
   $output.append(`<p>If you have code to share with the arXiv community, please ${submitItHereLink} to benefit all researchers & engineers.</p>`)

--- a/browse/static/js/catalyzex.js
+++ b/browse/static/js/catalyzex.js
@@ -57,6 +57,8 @@
       .append(codeLink)
   } else {
     $output.append(`<p>No code found for this paper just yet.</p>`)
+    const relatedCodeURL = `https://www.catalyzex.com/paper/arxiv:${arxivId}/code/related`
+    $output.append(`<p>See <a target="_blank" href="${relatedCodeURL}" style="font-weight:bold">code for related papers</a>.</p>`)
   }
   $output.append(`<p>If you have code to share with the arXiv community, please ${submitItHereLink} to benefit all researchers & engineers.</p>`)
 })();


### PR DESCRIPTION
With this, we will be able to show on the "CatalyzeX" section links to the `/related` code page for papers that still don't have code available.

note for the CX team (please don't include it in the PR against arxiv repo): I'm also sending the paper title via query params just so that we can use it as a fallback for papers that are not present in our DB, such as https://arxiv.org/abs/0906.5132. I also [updated the web app](https://github.com/gragtah/ProfillicDataMVP/pull/424/files#r1403807881) accordingly to handle these cases

⚠️ this PR also depends on the changes in [#442](https://github.com/gragtah/ProfillicDataMVP/pull/442), where I update the CX API to return the availability of similar results

It's already a dependency of #442, but worth keeping in mind that to get this live we should ship the "Related Code" feature on the web app, which is PR [424](https://github.com/gragtah/ProfillicDataMVP/pull/424).

### Demo

https://github.com/gragtah/arxiv-browse/assets/58868651/350c4e13-7474-4f34-a2b1-5342399480f6




