### PR TITLE
[CatalyzeX Integration] Allow users to create and visualize code alerts for papers

### DIFF
--- a/browse/static/js/catalyzex.js
+++ b/browse/static/js/catalyzex.js
@@ -58,7 +58,7 @@
 
   $output.html('');
 
-  const { count: implementations, cx_url: cxImplementationsUrl, is_alert_active: isAlertActive } = await fetchCatalyzeXCode()
+  const { count: implementations, cx_url: cxImplementationsUrl, is_alert_active: isAlertActive, authed_user_id: authedUserId } = await fetchCatalyzeXCode()
   $output.append("<h2>CatalyzeX</h2>");
 
   const addCodeURL = new URL("https://www.catalyzex.com/add_code");
@@ -82,9 +82,10 @@
     $output.append(`<p>No code found for this paper just yet.</p>`)
   }
   $output.append(`<p>If you have code to share with the arXiv community, please ${submitItHereLink} to benefit all researchers & engineers.</p>`)
-  
   if(isAlertActive) {
-    $output.append(`<p>You have created an alert for this paper and will be notified when new code is available 🔔</p>`)
+    $output.append(`
+      <p>You've set up an alert for this paper, and we'll notify you once new code becomes available. Manage all your alerts <a target="_blank" href="https://www.catalyzex.com/users/${authedUserId}/alerts">here</a>. 🚀
+   `)
   } else {
     const createAlertUrl = new URL("https://www.catalyzex.com/alerts/code/create");
     const queryParams = {

--- a/browse/static/js/catalyzex.js
+++ b/browse/static/js/catalyzex.js
@@ -4,6 +4,17 @@
   const paperUrl = window.location.href.split('?')[0];
   const $output = $("#catalyzex-output");
 
+  const url = new URL(location.href);
+  let cxToken = url.searchParams.get('cx_token');
+
+  if(cxToken) {
+    localStorage.setItem('@cx/token', cxToken)
+    url.searchParams.delete('cx_token')
+    window.history.replaceState({}, document.title, url.href);
+  } else {
+    cxToken = localStorage.getItem('@cx/token')
+  }
+
   if ($output.html() != "") {
     // Toggled off
     $output.html("");
@@ -19,14 +30,27 @@
   }
 
   const fetchCatalyzeXCode = async () => {
-    const cxApiUrl = `https://www.catalyzex.com/api/code?src=arxiv&paper_arxiv_id=${arxivId}`;
+    const cxApiUrl =  new URL("https://www.catalyzex.com/api/code")
+    const queryParams = {
+      src: 'arxiv',
+      paper_arxiv_id: arxivId,
+      paper_url: paperUrl,
+      paper_title: paperTitle
+    }
 
-    let result = {};
+    Object.entries(queryParams).forEach(([key, val]) => {
+      cxApiUrl.searchParams.set(key, val);
+    })
 
     try {
-      result = await $.ajax({ url: cxApiUrl, timeout: 2000, dataType: "json" });
+      result = await $.ajax({ 
+        url: cxApiUrl, 
+        timeout: 2000, 
+        dataType: "json",
+        headers: cxToken ? { 'Authorization': `Bearer ${cxToken}`} : undefined
+      });
     } catch (error) {
-      result = {};
+      result = error?.responseJSON || {};
     }
 
     return result;
@@ -34,8 +58,7 @@
 
   $output.html('');
 
-  const { count: implementations, cx_url: cxImplementationsUrl } = await fetchCatalyzeXCode()
-
+  const { count: implementations, cx_url: cxImplementationsUrl, is_alert_active: isAlertActive } = await fetchCatalyzeXCode()
   $output.append("<h2>CatalyzeX</h2>");
 
   const addCodeURL = new URL("https://www.catalyzex.com/add_code");
@@ -59,4 +82,20 @@
     $output.append(`<p>No code found for this paper just yet.</p>`)
   }
   $output.append(`<p>If you have code to share with the arXiv community, please ${submitItHereLink} to benefit all researchers & engineers.</p>`)
+  
+  if(isAlertActive) {
+    $output.append(`<p>You have created an alert for this paper and will be notified when new code is available 🔔</p>`)
+  } else {
+    const createAlertUrl = new URL("https://www.catalyzex.com/alerts/code/create");
+    const queryParams = {
+      paper_arxiv_id: arxivId,
+      paper_url: paperUrl,
+      paper_title: paperTitle,
+      redirect_url: paperUrl
+    }
+    Object.entries(queryParams).forEach(([key, val]) => {
+      createAlertUrl.searchParams.set(key, val);
+    })
+    $output.append(`<p><a href="${createAlertUrl}">Create an alert</a> to get notified when new code is available for this paper.</p>`)
+  }
 })();

--- a/browse/static/js/catalyzex.js
+++ b/browse/static/js/catalyzex.js
@@ -76,16 +76,15 @@
       .append(icons.catalyzex)
       .append("CatalyzeX");
 
-    $output
-      .append(codeLink)
+    $output.append(window.DOMPurify.sanitize(codeLink))
   } else {
     $output.append(`<p>No code found for this paper just yet.</p>`)
   }
-  $output.append(`<p>If you have code to share with the arXiv community, please ${submitItHereLink} to benefit all researchers & engineers.</p>`)
+  $output.append(window.DOMPurify.sanitize(`<p>If you have code to share with the arXiv community, please ${submitItHereLink} to benefit all researchers & engineers.</p>`))
   if(isAlertActive) {
-    $output.append(`
+    $output.append(window.DOMPurify.sanitize(`
       <p>You've set up an alert for this paper, and we'll notify you once new code becomes available. Manage all your alerts <a target="_blank" href="https://www.catalyzex.com/users/${authedUserId}/alerts">here</a>. 🚀
-   `)
+   `))
   } else {
     const createAlertUrl = new URL("https://www.catalyzex.com/alerts/code/create");
     const queryParams = {
@@ -97,6 +96,6 @@
     Object.entries(queryParams).forEach(([key, val]) => {
       createAlertUrl.searchParams.set(key, val);
     })
-    $output.append(`<p><a href="${createAlertUrl}">Create an alert</a> to get notified when new code is available for this paper.</p>`)
+    $output.append(window.DOMPurify.sanitize(`<p><a href="${createAlertUrl}">Create an alert</a> to get notified when new code is available for this paper.</p>`))
   }
 })();


### PR DESCRIPTION
note for CX team (do not include in the official PR): this PRs is blocked on [PR 491](https://github.com/gragtah/ProfillicDataMVP/pull/491) on the web app

The goal of this PR is to update CX's integration so that users can easily create code alerts for Arxiv papers. Apart from that, we're also displaying a custom message when we identify that a certain alert is already active.


https://github.com/gragtah/arxiv-browse/assets/58868651/8267d39e-6252-4200-9705-730321658481

