### PR TITLE
[CatalyzeX Integration] Add arxiv `src` to CatalyzeX links

### DIFF
--- a/browse/static/js/catalyzex.js
+++ b/browse/static/js/catalyzex.js
@@ -41,12 +41,15 @@
   const addCodeURL = new URL("https://www.catalyzex.com/add_code");
   addCodeURL.searchParams.set('title', paperTitle);
   addCodeURL.searchParams.set('paper_url', paperUrl);
+  addCodeURL.searchParams.set('src', 'arxiv');
 
   const submitItHereLink = `<a target="_blank" href="${addCodeURL}" style="font-weight:bold">submit it here</a>`;
 
   if (implementations) {
     const codeLink = $(`<a target="_blank"></a>`);
-    codeLink.attr("href", cxImplementationsUrl);
+    const codeLinkURL = new URL(cxImplementationsUrl);
+    codeLinkURL.searchParams.set('src', 'arxiv');
+    codeLink.attr("href", codeLinkURL);
     codeLink
       .append(icons.github)
       .append(`${implementations} code implementation${implementations > 1 ? "s" : ""} found on`)


### PR DESCRIPTION
_note for the CX team (do not include in the real PR): the changes to track these link clicks were introduced in [PR 554](https://github.com/gragtah/ProfillicDataMVP/pull/554)_

This PR updates all the hrefs to catalyzex.com to ensure a `src=arxiv` param is attached to the links, allowing us to track the usage of the links on our side

https://github.com/gragtah/ProfillicDataMVP/assets/58868651/bf21875b-2045-4027-9cdc-bf7810648aee